### PR TITLE
Fix Python 2 to 3 compatibility issues in pokedex codebase. 

### DIFF
--- a/pokedex/database/get.py
+++ b/pokedex/database/get.py
@@ -2,37 +2,10 @@
 
 import os
 import requests
-import zlib
 import gzip
 from progressbar import ProgressBar
 
 from .. import resource_path
-
-
-# def download_database():
-#     target = os.path.join(resource_path, "veekun-pokedex.sqlite")
-#     url = "http://veekun.com/static/pokedex/downloads/veekun-pokedex.sqlite.gz"
-    
-#     if os.path.isfile(target):
-#         return
-
-#     request = requests.get(url, stream=True)
-#     total_length = int(request.headers.get("content-length"))
-#     bytes_done = 0
-#     gzipped = ""
-
-#     print("Downloading Veekun Pokédex database...")
-#     with ProgressBar(max_value=total_length) as bar:
-#         for chunk in request.iter_content(chunk_size=1024):
-#             if chunk:
-#                 gzipped += chunk
-#                 bytes_done += len(chunk)
-#                 bar.update(bytes_done)
-
-#     decompressed_data = zlib.decompress(gzipped, 16+zlib.MAX_WBITS)
-
-#     with open(target, "wb") as file:
-#         file.write(decompressed_data)
 
 def download_database():
     target = os.path.join(resource_path, "veekun-pokedex.sqlite")

--- a/pokedex/database/get.py
+++ b/pokedex/database/get.py
@@ -3,10 +3,36 @@
 import os
 import requests
 import zlib
+import gzip
 from progressbar import ProgressBar
 
 from .. import resource_path
 
+
+# def download_database():
+#     target = os.path.join(resource_path, "veekun-pokedex.sqlite")
+#     url = "http://veekun.com/static/pokedex/downloads/veekun-pokedex.sqlite.gz"
+    
+#     if os.path.isfile(target):
+#         return
+
+#     request = requests.get(url, stream=True)
+#     total_length = int(request.headers.get("content-length"))
+#     bytes_done = 0
+#     gzipped = ""
+
+#     print("Downloading Veekun Pokédex database...")
+#     with ProgressBar(max_value=total_length) as bar:
+#         for chunk in request.iter_content(chunk_size=1024):
+#             if chunk:
+#                 gzipped += chunk
+#                 bytes_done += len(chunk)
+#                 bar.update(bytes_done)
+
+#     decompressed_data = zlib.decompress(gzipped, 16+zlib.MAX_WBITS)
+
+#     with open(target, "wb") as file:
+#         file.write(decompressed_data)
 
 def download_database():
     target = os.path.join(resource_path, "veekun-pokedex.sqlite")
@@ -18,7 +44,7 @@ def download_database():
     request = requests.get(url, stream=True)
     total_length = int(request.headers.get("content-length"))
     bytes_done = 0
-    gzipped = ""
+    gzipped = b""
 
     print("Downloading Veekun Pokédex database...")
     with ProgressBar(max_value=total_length) as bar:
@@ -28,7 +54,7 @@ def download_database():
                 bytes_done += len(chunk)
                 bar.update(bytes_done)
 
-    decompressed_data = zlib.decompress(gzipped, 16+zlib.MAX_WBITS)
+    decompressed_data = gzip.decompress(gzipped)
 
     with open(target, "wb") as file:
         file.write(decompressed_data)

--- a/pokedex/database/queries.py
+++ b/pokedex/database/queries.py
@@ -76,7 +76,7 @@ def get_pokemon_evolution_chain(pokemon_id, language=default_language):
                        WHERE evolution_chain_id = (SELECT evolution_chain_id FROM pokemon_species WHERE id={pokemon_id})
                    """.format(pokemon_id=pokemon_id))
     chain = [(row[0], get_pokemon_name(row[0], language), row[1]) for row in cursor.fetchall()]
-    root = (pkmn for pkmn in chain if pkmn[2] is None).next()
+    root = (pkmn for pkmn in chain if pkmn[2] is None).__next__()
     tree = {root: {}}
     del chain[chain.index(root)]
 

--- a/pokedex/formats.py
+++ b/pokedex/formats.py
@@ -11,7 +11,7 @@ format_names = ["card", "json", "simple", "line", "page"]
 
 def card(pokemon, shiny=False, mega=False):
 
-    evolutions_height = get_height(pokemon.chain.values()[0])
+    evolutions_height = get_height(list(pokemon.chain.values())[0])
     evolutions_width = get_width(pokemon.chain)
     content_width = max([evolutions_width, len(pokemon.genus) + 3 + 8 + 12, 32])
 
@@ -31,8 +31,8 @@ def card(pokemon, shiny=False, mega=False):
     buffer.put_line((3, 2), u"%s Pokémon" % pokemon.genus.capitalize(), fg=245, bg=0)
     buffer.put_line((3, 3), "%0.2f m / %0.1f kg" % (pokemon.height / 10.0, pokemon.weight / 10.0), fg=240, bg=0)
 
-    type1 = pokemon.types[0]
-    type2 = pokemon.types[1] if len(pokemon.types) > 1 else None
+    type1 = list(pokemon.types)[0]
+    type2 = list(pokemon.types)[1] if len(list(pokemon.types)) > 1 else None
 
     draw_number(buffer, pokemon.number, bg=0, x0=content_width-12, y0=1)
     draw_type(buffer, type1, type2, x0=3, y0=5)

--- a/pokedex/graphics/cell_buffer.py
+++ b/pokedex/graphics/cell_buffer.py
@@ -22,7 +22,7 @@ class Buffer(object):
         assert x < self.width
         assert y < self.height
 
-        assert type(character) in (str, unicode)
+        assert isinstance(character, str)
         if len(character) == 0:
             character = " "
 

--- a/pokedex/graphics/draw.py
+++ b/pokedex/graphics/draw.py
@@ -135,4 +135,4 @@ def draw_evolutions(buffer, chain, number, x0=0, y0=0, bg=-1):
                 draw(e, evolutions[e], longest, ox0 + ox1, oy0 + oy1 * 2 + last)
                 last = get_height(evolutions[e]) - 2
 
-    draw(chain.keys()[0], chain.values()[0], 0, 0, 0)
+    draw(list(chain.keys())[0], list(chain.values())[0], 0, 0, 0)


### PR DESCRIPTION
Specificaly, replace the use of the `next()` method with `__next__()` and ensure that all strings are of type `str`. Also, update the `download_database()` function to use the `gzip` module instead of `zlib`.